### PR TITLE
Have a clear distinction between line numbers and code

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -107,4 +107,16 @@ body {
 
   .border-top { border-top: 1px solid #e5e5e5; }
   .border-bottom { border-bottom: 1px solid #e5e5e5; }
+  .lineno {
+    color: #ccc;
+    padding: 0 5px;
+    margin-right: 5px;
+    border-right:1px solid #ccc;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
   h2, h4 { margin: 1rem 0; }


### PR DESCRIPTION
The line numbers were selectable and almost glued to the code in some cases.

Before my changes:
![before](https://user-images.githubusercontent.com/1102934/44662450-1eee5500-aa0e-11e8-8481-d538b01ff9be.png)

After my changes:
![after](https://user-images.githubusercontent.com/1102934/44662455-231a7280-aa0e-11e8-800a-22a0a5d76c71.png)