### PR TITLE
Add modal for confirmations instead of data-confirm boxes

### DIFF
--- a/_posts/components/2018-09-12-modal_confirm.html
+++ b/_posts/components/2018-09-12-modal_confirm.html
@@ -1,0 +1,28 @@
+---
+layout: post
+title:  Modal Confirm
+category: components
+description: To replace data-confirm dialogs and use our styled modal ones use this component. This is typically used for **link_to** that send (sometimes via Ajax) actions 
+             to the server that are destroying some data.
+---
+
+%h5 Trigger element
+
+%a{ href: "#", data: { toggle: "modal", target: "#confirm-modal-1234" }, title: "Delete a thing" }
+    %i.fas.fa-times-circle.text-danger
+    Delete
+
+.modal.fade{ id: "confirm-modal-1234", tabindex: -1, role: 'dialog', aria: { labelledby: 'confirm-modal-label', hidden: true } }
+    .modal-dialog.modal-dialog-centered{ role: 'document' }
+        .modal-content
+            .modal-header
+                %h5.modal-title
+                    Do you really want to delete a thing?
+            .modal-body
+                %p Please confirm that you want to delete a thing
+                //= form_tag(some_path(thing), method: :post) do
+                .modal-footer
+                    %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+                        Cancel
+                    //= submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+                    %input.btn.btn-sm.btn-danger.px-4{ type: "submit", name: "commit", value: "Delete", data: { disable: { with: "Delete" } } }


### PR DESCRIPTION
Add a component for showing a small centered modal usefull for
confirmations of destructive actions such as a deletion

It will show something like this:

![image](https://user-images.githubusercontent.com/11314634/45685564-f60f3a80-bb49-11e8-8e1f-dee8a587cf19.png)
