### PR TITLE
Add direction icons

### DIFF
--- a/_posts/content/2018-09-07-icons.html
+++ b/_posts/content/2018-09-07-icons.html
@@ -80,6 +80,16 @@ Delete
 %i.fas.fa-toggle-off{ title: 'Disable' }
 %br
 
+`Direction`:
+%i.fas.fa-chevron-down
+\/
+%i.fas.fa-chevron-left
+\/
+%i.fas.fa-chevron-right
+\/
+%i.fas.fa-chevron-up
+%br
+
 `Download`:
 %i.fas.fa-download.text-secondary
 Download


### PR DESCRIPTION
When reviewing @ChrisBr's PR https://github.com/openSUSE/open-build-service/pull/5943, I realized that we don't have icons to indicate direction.