### PR TITLE
Update publishing & unpublished build result icons

### DIFF
--- a/_posts/atoms/2018-09-07-icons.html
+++ b/_posts/atoms/2018-09-07-icons.html
@@ -47,7 +47,9 @@ Browse source
 \/
 %i.fas.fa-exclamation-triangle{ title: 'Broken' }
 \/
-%i.fas.fa-dolly-flatbed{ title: 'Publishing' }
+%i.fas.fa-dolly-flatbed{ title: 'Unpublished' }
+\/
+%i.fas.fa-truck-loading{ title: 'Publishing' }
 \/
 %i.fas.fa-truck{ title: 'Published' }
 \/


### PR DESCRIPTION
according to https://github.com/openSUSE/open-build-service/pull/6161.