### PR TITLE
Change assets url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,6 @@
   <link href="/assets/main.css" rel="stylesheet">
   <link href="/assets/syntax.css" rel="stylesheet">
 
-  <link rel="stylesheet" media="screen" href="https://build.opensuse.org/assets/webui2/webui2.css?{{ site.time | date: '%s%N' }}" />
-  <script src="https://build.opensuse.org/assets/webui2/application.js?{{ site.time | date: '%s%N' }}"></script>
+  <link rel="stylesheet" media="screen" href="https://build.opensuse.org/assets/webui/application.css?{{ site.time | date: '%s%N' }}" />
+  <script src="https://build.opensuse.org/assets/webui/application.js?{{ site.time | date: '%s%N' }}"></script>
 </head>


### PR DESCRIPTION
In OBS (Open Build Service), we are removing bento in favour of
bootstrap. For that reason the namespace `webui2` will disappear.

~~NOTE: DON'T MERGE IT until this [PR #8327](https://github.com/openSUSE/open-build-service/pull/8327) is merge.~~