### PR TITLE
Add history icon

### DIFF
--- a/_posts/atoms/2018-09-07-icons.html
+++ b/_posts/atoms/2018-09-07-icons.html
@@ -236,6 +236,11 @@ Cloud Upload
 Files
 %br
 
+`History`:
+%i.fas.fa-history
+Job History
+%br
+
 `Home`:
 %i.fas.fa-home{ title: 'Home' }
 %br


### PR DESCRIPTION
Right now, for the `Job History` link on the package binaries page, we use the `fa-list` icon. This is the same icon as for the `All Projects` link in the `Places` links.