### PR TITLE
Add/Regroup icons under their respective category

### DIFF
--- a/_posts/atoms/2018-09-07-icons.html
+++ b/_posts/atoms/2018-09-07-icons.html
@@ -128,11 +128,6 @@ Download
 Edit
 %br
 
-`Edit (for users)`:
-%i.fas.fa-user-edit
-Edit
-%br
-
 `Enable`:
 %i.fas.fa-toggle-on.text-primary
 Enable
@@ -180,9 +175,56 @@ Undo
 Upload
 %br
 
-%h3 Others
+%h3 Packages
 
-%p The following icons have to be categorized.
+%p These icons are used to represent packages and related entities.
+
+%i.fa.fa-archive.text-warning
+package123
+%br
+
+%i.fas.fa-copy.text-gray-500
+Files
+%br
+
+%i.fas.fa-band-aid
+Patchinfo
+%br
+
+#left-navigation-area
+  %span.fa-stack
+    %i.fas.fa-band-aid.fa-lg.fa-stack-1x
+    %i.fas.fa-plus-circle.fa-stack-1x.top-icon
+  Create Patchinfo
+  %br
+
+%h3 Users and Groups
+
+%p These icons are used to represent users, groups and related entities.
+
+%i.fas.fa-user-edit
+Edit
+%br
+
+%h3 Projects
+
+%p These icons are used to represent projects and related entities.
+
+%i.fa.fa-cubes.text-secondary
+project123
+%br
+
+%h3 Images
+
+%p These icons are used to represent images and related entities.
+
+%i.fas.fa-compact-disc.text-secondary
+kiwi_image123
+%br
+
+%h3 Generic
+
+%p The following icons don't belong to another category.
 
 `Announcement`:
 %i.fa.fa-exclamation-circle.text-danger{ title: 'Alert' }
@@ -241,11 +283,6 @@ Cloud Upload
 %i.far.fa-envelope{ title: 'Send email to blabla' }
 %br
 
-`Files`:
-%i.fas.fa-copy.text-gray-550
-Files
-%br
-
 `History`:
 %i.fas.fa-history
 Job History
@@ -255,11 +292,6 @@ Job History
 %i.fas.fa-home{ title: 'Home' }
 %br
 
-`Image`:
-%i.fas.fa-compact-disc.text-secondary
-Image
-%br
-
 `Link`:
 %i.fas.fa-link
 Links to project123
@@ -267,16 +299,6 @@ Links to project123
 
 `List`:
 %i.fas.fa-list{ title: 'List projects' }
-%br
-
-`Package`:
-%i.fa.fa-archive.text-warning
-My package 123
-%br
-
-`Project`:
-%i.fa.fa-cubes.text-secondary
-My project 123
 %br
 
 `RSS Feed`:


### PR DESCRIPTION
The stacked icons from https://github.com/openSUSE/open-build-service/pull/10473 are included. Other icons were added if they were missing. The icons have been regrouped in categories.